### PR TITLE
Add GitHub Skills extracurricular activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical GitHub workflows and collaboration skills from the school’s new partnership with GitHub.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
- add the "GitHub Skills" activity to the in-memory activity catalog
- set its schedule, capacity, and description so students can register immediately

## Testing
- `python -m py_compile src/app.py`
